### PR TITLE
[#67] foundationdb 벤치마크 추가

### DIFF
--- a/database_write_performance/Cargo.lock
+++ b/database_write_performance/Cargo.lock
@@ -133,6 +133,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +282,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.9.3",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease 0.2.37",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +434,17 @@ name = "cityhash-rs"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clickhouse"
@@ -715,6 +766,7 @@ dependencies = [
  "clickhouse",
  "couch_rs",
  "etcd-rs",
+ "foundationdb",
  "futures",
  "influxdb",
  "influxdb2",
@@ -1037,6 +1089,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "foundationdb"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514aeffe12bbcf2f64a746793cc1c2602006c705d3fc6285df024303d008cccf"
+dependencies = [
+ "async-recursion 1.1.1",
+ "async-trait",
+ "foundationdb-gen",
+ "foundationdb-macros",
+ "foundationdb-sys",
+ "foundationdb-tuple",
+ "futures",
+ "memchr",
+ "rand 0.8.5",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
+name = "foundationdb-gen"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef9d854866df33e1f4099769e2b9fa8bf8cf3bca707029ae6298d0e61bcae358"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
+name = "foundationdb-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be610412e5a92d89855fb15b099a57792b7dbdcf8ac74c5a0e24d9b7b1b6f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "try_map",
+]
+
+[[package]]
+name = "foundationdb-sys"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bae14dba30b8dcc4905a9189ebb18bc9db9744ef0ad8f2b94ef00d21e176964"
+dependencies = [
+ "bindgen",
+ "libc",
+]
+
+[[package]]
+name = "foundationdb-tuple"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1832c1fbe592de718893f7c3b48179a47757f8974d1498fece997454c2b0fa"
+dependencies = [
+ "memchr",
+ "uuid",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1307,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "go-parse-duration"
@@ -1918,6 +2036,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2329,16 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "signatory",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2515,6 +2659,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,7 +2751,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost 0.11.9",
  "prost-types",
  "regex",
@@ -2986,6 +3140,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -3949,7 +4109,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048968e4e3d04db472346770cc19914c6b5ae206fa44677f6a0874d54cd05940"
 dependencies = [
- "async-recursion",
+ "async-recursion 0.3.2",
  "async-trait",
  "derive-new",
  "either",
@@ -4198,7 +4358,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build",
  "quote",
@@ -4307,6 +4467,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "try_map"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1626d07cb5c1bb2cf17d94c0be4852e8a7c02b041acec9a8c5bdda99f9d580"
 
 [[package]]
 name = "tryhard"
@@ -4871,6 +5037,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "yoke"

--- a/database_write_performance/Cargo.toml
+++ b/database_write_performance/Cargo.toml
@@ -9,6 +9,7 @@ async-trait = "0.1.89"
 clickhouse = "0.13.3"
 couch_rs = "0.10.1"
 etcd-rs = "1.0.1"
+foundationdb = "0.9.2"
 futures = "0.3.31"
 influxdb2 = "0.5.1"
 influxdb = { version = "0.7.2", features = ["derive"] }

--- a/database_write_performance/docker-compose.yml
+++ b/database_write_performance/docker-compose.yml
@@ -250,6 +250,21 @@ services:
           cpus: "4"
           memory: 8096M
   
+  foundationdb:
+    image: foundationdb/foundationdb:7.1.61
+    environment:
+      FDB_NETWORKING_MODE: host
+    ports:
+      - "4500:4500"   # FoundationDB coordinator port
+    volumes:
+      - fdb_data:/var/fdb/data
+      - fdb_logs:/var/fdb/logs
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8096M
+  
   # TiKV single node setup (minimal config)
   pd:
     image: pingcap/pd:v8.5.0
@@ -326,4 +341,8 @@ volumes:
   pd_data:
     driver: local
   tikv_data:
+    driver: local
+  fdb_data:
+    driver: local
+  fdb_logs:
     driver: local

--- a/database_write_performance/src/db/foundationdb.rs
+++ b/database_write_performance/src/db/foundationdb.rs
@@ -1,0 +1,110 @@
+use foundationdb::*;
+use std::sync::Arc;
+
+use super::{Database, Errors, Result};
+
+pub struct FoundationDB {
+    db: foundationdb::Database,
+}
+
+impl FoundationDB {
+    pub async fn new() -> Result<Arc<dyn Database + Send + Sync>> {
+        // FoundationDB 네트워크 초기화
+        let network = FdbClusterFile::default()
+            .connect()
+            .await
+            .map_err(|error| Errors::ConnectionError(error.to_string()))?;
+
+        // 기본 데이터베이스 열기
+        let db = network
+            .open_database(b"")
+            .await
+            .map_err(|error| Errors::ConnectionError(error.to_string()))?;
+
+        Ok(Arc::new(FoundationDB { db }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Database for FoundationDB {
+    async fn ping(&self) -> Result<()> {
+        // FoundationDB에서는 간단한 트랜잭션으로 연결 확인
+        let transaction = self.db.create_trx().expect("Failed to create transaction");
+
+        // 테스트용 키로 get 연산 수행
+        let test_key = b"__ping_test__";
+
+        match transaction.get(test_key, false).await {
+            Ok(_) => {
+                transaction.commit().await.map_err(|error| {
+                    Errors::ConnectionError(format!("Failed to commit ping transaction: {}", error))
+                })?;
+                Ok(())
+            }
+            Err(error) => Err(Errors::ConnectionError(error.to_string())),
+        }
+    }
+
+    async fn setup(&self) -> Result<()> {
+        // FoundationDB는 schema-less이므로 별도 테이블 생성이 필요 없음
+        // 기존 벤치마크 키들을 정리 (선택적)
+
+        let transaction = self.db.create_trx().expect("Failed to create transaction");
+
+        // 벤치마크 네임스페이스 접두사
+        let prefix = b"benchmark:";
+        let end_key = b"benchmark;"; // ':' 다음 문자로 range 끝 설정
+
+        // 기존 키들을 스캔하고 삭제 (선택적)
+        match transaction
+            .get_range(
+                RangeOption {
+                    begin: KeySelector::first_greater_or_equal(prefix),
+                    end: KeySelector::first_greater_or_equal(end_key),
+                    limit: Some(1000),
+                    reverse: false,
+                    mode: StreamingMode::WantAll,
+                },
+                false,
+            )
+            .await
+        {
+            Ok(range_result) => {
+                let kvs = range_result.key_values();
+                if !kvs.is_empty() {
+                    for kv in kvs {
+                        transaction.clear(&kv.key());
+                    }
+                }
+
+                transaction.commit().await.map_err(|error| {
+                    Errors::ConnectionError(format!(
+                        "Failed to commit setup transaction: {}",
+                        error
+                    ))
+                })?;
+            }
+            Err(_) => {
+                // 스캔 실패는 무시 (키가 없을 수 있음)
+                transaction.reset();
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn write(&self, key: &str, value: &str) -> Result<()> {
+        let transaction = self.db.create_trx().expect("Failed to create transaction");
+
+        // 벤치마크 네임스페이스 추가
+        let namespaced_key = format!("benchmark:{}", key);
+
+        transaction.set(namespaced_key.as_bytes(), value.as_bytes());
+
+        transaction.commit().await.map_err(|error| {
+            Errors::WriteError(format!("Failed to write to FoundationDB: {}", error))
+        })?;
+
+        Ok(())
+    }
+}

--- a/database_write_performance/src/db/mod.rs
+++ b/database_write_performance/src/db/mod.rs
@@ -5,6 +5,7 @@ pub mod clickhouse;
 pub mod cockroachdb;
 pub mod couchdb;
 pub mod etcd;
+pub mod foundationdb;
 pub mod influxdb_v2;
 pub mod mariadb;
 pub mod mongodb;
@@ -48,6 +49,7 @@ pub async fn new_database(db_type: &str) -> Result<Arc<dyn Database + Send + Syn
         "nats" => nats::NatsJetStream::new().await,
         "tidb" => tidb::TiDB::new().await,
         "tikv" => tikv::TiKV::new().await,
+        "foundationdb" => foundationdb::FoundationDB::new().await,
         _ => Err(Errors::ConnectionError("Unknown database type".into())),
     }
 }


### PR DESCRIPTION
```
error: couldn't read `/usr/include/foundationdb/fdb.options`: No such file or directory (os error 2)
   --> /home/myyrakle/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/foundationdb-gen-0.9.2/src/lib.rs:352:29
    |
352 | const OPTIONS_DATA: &[u8] = include_bytes!("/usr/include/foundationdb/fdb.options");
```
클라이언트 컴파일 실패